### PR TITLE
Add AI-based fault prediction

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import plotly.graph_objects as go
 import plotly.express as px
 import pandas as pd
 from data_simulator import get_live_data
+from fault_predictor import predict_fault
 import time
 
 # --- Page Config ---
@@ -146,6 +147,16 @@ with machine_kpi_cols[3]:
 with machine_kpi_cols[4]:
     total_cost_m = selected_machine_df["energy_cost"].sum()
     st.markdown(f"<div class='metric-card'><div class='metric-value'>${total_cost_m:.2f}</div><div class='metric-label'>Total Energy Cost</div></div>", unsafe_allow_html=True)
+
+# --- AI Fault Prediction ---
+probability, downtime_hours, explanation = predict_fault(selected_row, history_df)
+st.markdown("### 🧠 AI Fault Prediction")
+ai_cols = st.columns(2)
+with ai_cols[0]:
+    st.markdown(f"<div class='metric-card'><div class='metric-value'>{probability*100:.1f}%</div><div class='metric-label'>Failure Probability</div></div>", unsafe_allow_html=True)
+with ai_cols[1]:
+    st.markdown(f"<div class='metric-card'><div class='metric-value'>{downtime_hours:.1f} hrs</div><div class='metric-label'>Est. Downtime</div></div>", unsafe_allow_html=True)
+st.markdown(f"**Explanation:** {explanation}")
 
 # --- Alerts ---
 alert_conditions = []

--- a/fault_predictor.py
+++ b/fault_predictor.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+# Thresholds used to label data for the simple predictive model
+FAULT_THRESHOLDS = {
+    "oil_temp": 110,
+    "vibration": 10,
+    "bearing_temp": 115,
+}
+
+def _prepare_training_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of df with a derived 'fault' label column."""
+    labeled = df.copy()
+    labeled["fault"] = (
+        (labeled["oil_temp"] > FAULT_THRESHOLDS["oil_temp"]) |
+        (labeled["vibration"] > FAULT_THRESHOLDS["vibration"]) |
+        (labeled["bearing_temp"] > FAULT_THRESHOLDS["bearing_temp"])
+    ).astype(int)
+    return labeled
+
+def _train_model(df: pd.DataFrame):
+    """Train a simple logistic regression model if possible."""
+    data = _prepare_training_data(df)
+    X = data[["oil_temp", "hydraulic_temp", "bearing_temp", "vibration"]]
+    y = data["fault"]
+    if y.nunique() < 2:
+        return None
+    try:
+        model = LogisticRegression()
+        model.fit(X, y)
+        return model
+    except Exception:
+        return None
+
+def predict_fault(selected_row: pd.Series, history_df: pd.DataFrame):
+    """Predict fault probability and downtime for the selected machine.
+
+    Returns (probability, downtime_hours, explanation).
+    """
+    model = _train_model(history_df)
+    features = selected_row[["oil_temp", "hydraulic_temp", "bearing_temp", "vibration"]].values.reshape(1, -1)
+    # Basic explanation based on threshold breaches
+    reasons = []
+    for col, thresh in FAULT_THRESHOLDS.items():
+        if selected_row[col] > thresh:
+            reasons.append(f"{col.replace('_', ' ').title()} above {thresh}")
+    if model is None:
+        probability = 0.0
+    else:
+        probability = float(model.predict_proba(features)[0, 1])
+    downtime = max(0.5, probability * 5)
+    if reasons:
+        explanation = ", ".join(reasons)
+    elif model is None:
+        explanation = "Insufficient data to train predictive model"
+    else:
+        explanation = "No critical readings detected"
+    return probability, downtime, explanation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit>=1.30.0
 plotly>=5.20.0
 pandas>=2.1.0
+scikit-learn>=1.3.0


### PR DESCRIPTION
## Summary
- import new fault predictor into the dashboard
- predict fault probability and downtime using logistic regression on the simulated data
- show predictions and explanation in the dashboard UI
- add scikit-learn as a requirement

## Testing
- `python -m py_compile app.py data_simulator.py fault_predictor.py`


------
https://chatgpt.com/codex/tasks/task_e_6841b4fa8140833392d0ea9250b89b53