### PR TITLE
Fix gauge threshold line behavior

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,7 +80,7 @@ def create_gauge(value, green_range, orange_range, red_range, unit='°C'):
             'bgcolor': "rgba(0,0,0,0.1)",
             'borderwidth': 0,
             'steps': [],
-            'threshold': {'line': {'color': "white", 'width': 4}, 'thickness': 0.75, 'value': value}
+            'threshold': {'line': {'color': "white", 'width': 4}, 'thickness': 0.75, 'value': red_range[0]}
         }
     ))
     fig.update_traces(gauge_shape="angular")


### PR DESCRIPTION
## Summary
- keep gauge threshold constant by using `red_range[0]`

## Testing
- `python -m py_compile app.py`
- `streamlit run app.py --server.headless true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b601ae3883339b4a18a25e1b38a4